### PR TITLE
fix: wrong link

### DIFF
--- a/bots/settings/README.md
+++ b/bots/settings/README.md
@@ -1,3 +1,3 @@
 # 봇 설정
 
-- [봇 토큰 확인하기](/bots/settings/token)
+- [봇 토큰 확인하기](/bots/settings/token.md)


### PR DESCRIPTION
The github README.md link is wrong and it shows a 404.